### PR TITLE
Create build and release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,31 @@
+name: Build & Publish Release APK
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  Gradle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: setup jdk
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Build apk
+        uses: sparkfabrik/android-build-action@v1.5.0
+        with:
+          project-path: .
+          output-path: luebeck-mensa-widget-${{ github.ref_name }}.apk
+      - name: Release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: ${{ github.ref_name }}
+          draft: true
+          title: ${{ github.ref_name }}
+          files: |
+            luebeck-mensa-widget-${{ github.ref_name }}.apk


### PR DESCRIPTION
This pull request adds a Build and Release GitHub Workflow. It is triggered whenever a new tag is pushed. It then builds the app as apk and drafts a release with the file attached.